### PR TITLE
Add custom labels implementation

### DIFF
--- a/server_metrics_custom_labels.go
+++ b/server_metrics_custom_labels.go
@@ -1,0 +1,224 @@
+package grpc_prometheus
+
+import (
+	prom "github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	defaultLables = []string{"grpc_type", "grpc_service", "grpc_method"}
+)
+
+// CustomLabelsProvider defines method that custom label provider must implement
+type CustomLabelsProvider interface {
+	AllPossibleLabels() map[string][]string
+	LabelsFromContext(ctx context.Context) []string
+}
+
+// ServerMetricsCustomLabels represents a collection of metrics to be registered on a
+// Prometheus metrics registry for a gRPC server.
+type ServerMetricsCustomLabels struct {
+	serverStartedCounter          *prom.CounterVec
+	serverHandledCounter          *prom.CounterVec
+	serverStreamMsgReceived       *prom.CounterVec
+	serverStreamMsgSent           *prom.CounterVec
+	serverHandledHistogramEnabled bool
+	serverHandledHistogramOpts    prom.HistogramOpts
+	serverHandledHistogram        *prom.HistogramVec
+	customLabelsProvider          CustomLabelsProvider
+	customLabels                  []string
+}
+
+// NewServerMetricsCustomLabels returns a ServerMetrics object. Use a new instance of
+// ServerMetrics when not using the default Prometheus metrics registry, for
+// example when wanting to control which metrics are added to a registry as
+// opposed to automatically adding metrics via init functions.
+func NewServerMetricsCustomLabels(clp CustomLabelsProvider, counterOpts ...CounterOption) *ServerMetricsCustomLabels {
+	var additionalLabels []string
+	if clp != nil {
+		labels := clp.AllPossibleLabels()
+		if labels != nil {
+			keys := make([]string, 0, len(labels))
+			for k := range labels {
+				keys = append(keys, k)
+			}
+			additionalLabels = keys
+		}
+	}
+	finalLabels := make([]string, 0, len(defaultLables)+len(additionalLabels))
+	finalLabels = append(finalLabels, defaultLables...)
+	customLabels := append(finalLabels, additionalLabels...)
+
+	handledLabels := make([]string, len(customLabels)+1)
+	copy(handledLabels, customLabels)
+	handledLabels[len(customLabels)] = "grpc_code"
+
+	opts := counterOptions(counterOpts)
+	result := &ServerMetricsCustomLabels{
+		customLabelsProvider: clp,
+		customLabels:         customLabels,
+		serverStartedCounter: prom.NewCounterVec(
+			opts.apply(prom.CounterOpts{
+				Name: "grpc_server_started_with_labels_total",
+				Help: "Total number of RPCs started on the server.",
+			}), customLabels),
+		serverHandledCounter: prom.NewCounterVec(
+			opts.apply(prom.CounterOpts{
+				Name: "grpc_server_handled_with_labels_total",
+				Help: "Total number of RPCs completed on the server, regardless of success or failure.",
+			}), handledLabels),
+		serverStreamMsgReceived: prom.NewCounterVec(
+			opts.apply(prom.CounterOpts{
+				Name: "grpc_server_msg_received_with_labels_total",
+				Help: "Total number of RPC stream messages received on the server.",
+			}), customLabels),
+		serverStreamMsgSent: prom.NewCounterVec(
+			opts.apply(prom.CounterOpts{
+				Name: "grpc_server_msg_sent_with_labels_total",
+				Help: "Total number of gRPC stream messages sent by the server.",
+			}), customLabels),
+		serverHandledHistogramEnabled: false,
+		serverHandledHistogramOpts: prom.HistogramOpts{
+			Name:    "grpc_server_handling_with_labels_seconds",
+			Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+			Buckets: prom.DefBuckets,
+		},
+		serverHandledHistogram: nil,
+	}
+	prom.MustRegister(result.serverStartedCounter)
+	prom.MustRegister(result.serverHandledCounter)
+	prom.MustRegister(result.serverStreamMsgReceived)
+	prom.MustRegister(result.serverStreamMsgSent)
+	return result
+}
+
+// EnableHandlingTimeHistogram enables histograms being registered when
+// registering the ServerMetrics on a Prometheus registry. Histograms can be
+// expensive on Prometheus servers. It takes options to configure histogram
+// options such as the defined buckets.
+func (m *ServerMetricsCustomLabels) EnableHandlingTimeHistogram(opts ...HistogramOption) {
+	for _, o := range opts {
+		o(&m.serverHandledHistogramOpts)
+	}
+	if !m.serverHandledHistogramEnabled {
+		m.serverHandledHistogram = prom.NewHistogramVec(
+			m.serverHandledHistogramOpts,
+			m.customLabels,
+		)
+	}
+	m.serverHandledHistogramEnabled = true
+	prom.Register(m.serverHandledHistogram)
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector to the provided channel and returns once
+// the last descriptor has been sent.
+func (m *ServerMetricsCustomLabels) Describe(ch chan<- *prom.Desc) {
+	m.serverStartedCounter.Describe(ch)
+	m.serverHandledCounter.Describe(ch)
+	m.serverStreamMsgReceived.Describe(ch)
+	m.serverStreamMsgSent.Describe(ch)
+	if m.serverHandledHistogramEnabled {
+		m.serverHandledHistogram.Describe(ch)
+	}
+}
+
+// Collect is called by the Prometheus registry when collecting
+// metrics. The implementation sends each collected metric via the
+// provided channel and returns once the last metric has been sent.
+func (m *ServerMetricsCustomLabels) Collect(ch chan<- prom.Metric) {
+	m.serverStartedCounter.Collect(ch)
+	m.serverHandledCounter.Collect(ch)
+	m.serverStreamMsgReceived.Collect(ch)
+	m.serverStreamMsgSent.Collect(ch)
+	if m.serverHandledHistogramEnabled {
+		m.serverHandledHistogram.Collect(ch)
+	}
+}
+
+// UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
+func (m *ServerMetricsCustomLabels) UnaryServerInterceptor() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		monitor := newServerReporterCustomLabels(ctx, m, Unary, info.FullMethod)
+		monitor.ReceivedMessage()
+		resp, err := handler(ctx, req)
+		st, _ := status.FromError(err)
+		monitor.Handled(st.Code())
+		if err == nil {
+			monitor.SentMessage()
+		}
+		return resp, err
+	}
+}
+
+// StreamServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Streaming RPCs.
+func (m *ServerMetricsCustomLabels) StreamServerInterceptor() func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		monitor := newServerReporterCustomLabels(ss.Context(), m, streamRPCTypeCustomLabels(info), info.FullMethod)
+		err := handler(srv, &monitoredServerStreamCustomLabels{ss, monitor})
+		st, _ := status.FromError(err)
+		monitor.Handled(st.Code())
+		return err
+	}
+}
+
+// InitializeMetrics initializes all metrics, with their appropriate null
+// value, for all gRPC methods registered on a gRPC server. This is useful, to
+// ensure that all metrics exist when collecting and querying.
+func (m *ServerMetricsCustomLabels) InitializeMetrics(server *grpc.Server) {
+	serviceInfo := server.GetServiceInfo()
+	for serviceName, info := range serviceInfo {
+		for _, mInfo := range info.Methods {
+			preRegisterMethodCustomLabels(m, serviceName, &mInfo)
+		}
+	}
+}
+
+func streamRPCTypeCustomLabels(info *grpc.StreamServerInfo) grpcType {
+	if info.IsClientStream && !info.IsServerStream {
+		return ClientStream
+	} else if !info.IsClientStream && info.IsServerStream {
+		return ServerStream
+	}
+	return BidiStream
+}
+
+// monitoredStream wraps grpc.ServerStream allowing each Sent/Recv of message to increment counters.
+type monitoredServerStreamCustomLabels struct {
+	grpc.ServerStream
+	monitor *serverReporterCustomLabels
+}
+
+func (s *monitoredServerStreamCustomLabels) SendMsg(m interface{}) error {
+	err := s.ServerStream.SendMsg(m)
+	if err == nil {
+		s.monitor.SentMessage()
+	}
+	return err
+}
+
+func (s *monitoredServerStreamCustomLabels) RecvMsg(m interface{}) error {
+	err := s.ServerStream.RecvMsg(m)
+	if err == nil {
+		s.monitor.ReceivedMessage()
+	}
+	return err
+}
+
+// preRegisterMethod is invoked on Register of a Server, allowing all gRPC services labels to be pre-populated.
+func preRegisterMethodCustomLabels(metrics *ServerMetricsCustomLabels, serviceName string, mInfo *grpc.MethodInfo) {
+	methodName := mInfo.Name
+	methodType := string(typeFromMethodInfo(mInfo))
+	// These are just references (no increments), as just referencing will create the labels but not set values.
+	metrics.serverStartedCounter.GetMetricWithLabelValues(methodType, serviceName, methodName)
+	metrics.serverStreamMsgReceived.GetMetricWithLabelValues(methodType, serviceName, methodName)
+	metrics.serverStreamMsgSent.GetMetricWithLabelValues(methodType, serviceName, methodName)
+	if metrics.serverHandledHistogramEnabled {
+		metrics.serverHandledHistogram.GetMetricWithLabelValues(methodType, serviceName, methodName)
+	}
+	for _, code := range allCodes {
+		metrics.serverHandledCounter.GetMetricWithLabelValues(methodType, serviceName, methodName, code.String())
+	}
+}

--- a/server_reporter_custom_labels.go
+++ b/server_reporter_custom_labels.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_prometheus
+
+import (
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"context"
+)
+
+type serverReporterCustomLabels struct {
+	metrics     *ServerMetricsCustomLabels
+	rpcType     grpcType
+	serviceName string
+	methodName  string
+	startTime   time.Time
+	labelValues []string
+}
+
+func newServerReporterCustomLabels(ctx context.Context, m *ServerMetricsCustomLabels, rpcType grpcType, fullMethod string) *serverReporterCustomLabels {
+	r := &serverReporterCustomLabels{
+		metrics: m,
+		rpcType: rpcType,
+	}
+
+	if r.metrics.serverHandledHistogramEnabled {
+		r.startTime = time.Now()
+	}
+
+	r.serviceName, r.methodName = splitMethodName(fullMethod)
+	labelValues := make([]string, len(m.customLabels), len(m.customLabels))
+	copy(labelValues, []string{string(r.rpcType), r.serviceName, r.methodName})
+	customLabelValues := m.customLabelsProvider.LabelsFromContext(ctx)
+	for i := len(defaultLables); i < len(m.customLabels); i++ {
+		si := i - len(defaultLables) //shifted index
+		if si >= len(customLabelValues) {
+			break
+		}
+		labelValues[i] = customLabelValues[si]
+	}
+	r.labelValues = labelValues
+
+	r.metrics.serverStartedCounter.WithLabelValues(r.labelValues...).Inc()
+	return r
+}
+
+func (r *serverReporterCustomLabels) ReceivedMessage() {
+	r.metrics.serverStreamMsgReceived.WithLabelValues(r.labelValues...).Inc()
+}
+
+func (r *serverReporterCustomLabels) SentMessage() {
+	r.metrics.serverStreamMsgSent.WithLabelValues(r.labelValues...).Inc()
+}
+
+func (r *serverReporterCustomLabels) Handled(code codes.Code) {
+	lvs := r.labelValues
+	lvs = append(lvs, code.String())
+	r.metrics.serverHandledCounter.WithLabelValues(lvs...).Inc()
+	if r.metrics.serverHandledHistogramEnabled {
+		r.metrics.serverHandledHistogram.WithLabelValues(r.labelValues...).Observe(time.Since(r.startTime).Seconds())
+	}
+}


### PR DESCRIPTION
We would really like to be able to add custom labels such as UserAgent to standard GRPC metrics. 
This does the trick.